### PR TITLE
fix dubious ownership error message

### DIFF
--- a/distributeApp.sh
+++ b/distributeApp.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 set -e
+set -o pipefail
+
+# Fix the unsafe repo error which was introduced by the CVE-2022-24765 git patches
+git config --global --add safe.directory /github/workspace
 
 if [[ -z ${INPUT_RELEASE_NOTES} ]]; then
     INPUT_RELEASE_NOTES="$(git log -1 --abbrev-commit --pretty=oneline)"


### PR DESCRIPTION
This fixes error message `fatal: detected dubious ownership in repository at '/github/workspace'` referenced in issue https://github.com/hasretsariyer/firebase-app-distribution-github-action/issues/4 

I found the solution documented here: https://github.com/repo-sync/pull-request/issues/84